### PR TITLE
Added API call for delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ write {json file}
 ```
 or after running the cli as 
 ```
-read {user's name}`
+read {user's name}
 ```
 - `list`: Can use this command as 
 ```
@@ -39,6 +39,15 @@ list
 ```
 - `help`: Can use this command as `./cli` or `./cli -h` or `./cli help`. This command will show information about the CLI.
 
+- `delete`: Can use the command as
+```
+./cli delete {user's name}
+```
+or after running the cli as
+```
+delete {user's name}
+```
+
 There are two ways to access the CLI:
 - By running it in interactive mode (note the aliases can be used instead of the full command), for example: 
 ```
@@ -46,9 +55,11 @@ $ ./cli
 # Enter command or enter q to quit: write example.json
 # Enter command or enter q to quit: read user
 # Enter command or enter q to quit: list
+# Enter command or enter q to quit: delete user
 # Enter command or enter q to quit: w example.json
 # Enter command or enter q to quit: r user
 # Enter command or enter q to quit: l
+# Enter command or enter q to quit: d user
 # Enter command or enter q to quit: q
 ```
 
@@ -57,9 +68,11 @@ $ ./cli
 $ ./cli write example.json
 $ ./cli read user
 $ ./cli list
+$ ./cli read user
 $ ./cli w example.json
 $ ./cli r user
 $ ./cli l
+$ ./cli d user
 $ ./cli help
 ```
 ## Verify that Data in Vault

--- a/cli/configSettings/getToken.go
+++ b/cli/configSettings/getToken.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 )
 
 func GetToken() string {
@@ -14,6 +15,8 @@ func GetToken() string {
 	}
 
 	tokenStr := string(token)
+	finalToken := strings.TrimSuffix(tokenStr, "\n")
 
-	return tokenStr
+	return finalToken
+
 }

--- a/cli/configSettings/token.txt
+++ b/cli/configSettings/token.txt
@@ -1,1 +1,1 @@
-{insert-token-here}
+{isert-token-here}

--- a/cli/configSettings/token.txt
+++ b/cli/configSettings/token.txt
@@ -1,1 +1,1 @@
-{isert-token-here}
+{insert-token-here}

--- a/cli/handlers/handlers.go
+++ b/cli/handlers/handlers.go
@@ -72,12 +72,30 @@ func ListUserInfo(token string) {
 	if err != nil {
 		log.Fatalf("Unable to list secret: %v", err)
 	}
-	datamap := listSecret.Data
-	data := datamap["keys"].([]interface{})
-	for _, n := range data {
-		nStr := fmt.Sprint(n)
-		fmt.Println(n)
-		ReadUserInfo(token, nStr)
-		fmt.Println("-------------------------") // just for legibility purposes
+	if listSecret != nil {
+		datamap := listSecret.Data
+		data := datamap["keys"].([]interface{})
+		for _, n := range data {
+			nStr := fmt.Sprint(n)
+			fmt.Println(n)
+			ReadUserInfo(token, nStr)
+			fmt.Println("-------------------------") // just for legibility purposes
+		}
+	}
+}
+
+// Used to read metadata from Vault
+func DeleteUserInfo(token string, name string) {
+	client, _ := cs.Client(token)
+	endpoint := "identity/entity/name/" + name
+	secret, err := client.Logical().Delete(endpoint)
+	if err != nil {
+		log.Fatalf("Unable to delete secret: %v", err)
+	}
+	if secret == nil {
+		fmt.Println("User sucessfully deleted from Vault.")
+	} else {
+		errMsg := name + " does not exist in Vault."
+		fmt.Println(errMsg)
 	}
 }

--- a/cli/interactiveApp.go
+++ b/cli/interactiveApp.go
@@ -36,6 +36,11 @@ func interactiveApp() {
 			if rightInput {
 				h.ListUserInfo(cs.TOKEN)
 			}
+		} else if (command == "delete" || command == "d") && len(newRes) >= 2 {
+			rightInput := v.ValidateDelete(cs.TOKEN, newRes[1])
+			if rightInput {
+				h.DeleteUserInfo(cs.TOKEN, newRes[1])
+			}
 		} else if command == "exit" || command == "q" {
 			break
 		} else {

--- a/cli/main.go
+++ b/cli/main.go
@@ -57,6 +57,19 @@ func main() {
 					return nil
 				},
 			},
+			{
+				Name:    "delete",
+				Aliases: []string{"d"},
+				Usage:   "delete user from vault (provide 1 argument - name of user)",
+				Action: func(c *cli.Context) error {
+					cArg0 := c.Args().Get(0)
+					rightInput := v.ValidateDelete(cs.TOKEN, cArg0)
+					if rightInput {
+						h.DeleteUserInfo(cs.TOKEN, cArg0)
+					}
+					return nil
+				},
+			},
 		},
 	}
 

--- a/cli/validators/validators.go
+++ b/cli/validators/validators.go
@@ -44,3 +44,16 @@ func ValidateList(token string) bool {
 		return false
 	}
 }
+
+// Basic error handling for number of arguments (delelte call)
+func ValidateDelete(token string, arg1 string) bool {
+	if token != "" && arg1 != "" {
+		return true
+	} else if token == "" && arg1 == "" {
+		fmt.Println("No arguments provided, missing token and user's name")
+		return false
+	} else {
+		fmt.Println("Only one argument provided")
+		return false
+	}
+}


### PR DESCRIPTION
## Description

Added API call for `delete`. Added a handler function and a vaildator one. The latter might not be strictly necessary as there is duplication with read, but might have to update names in that case. I kept it separate in case more functionality is added later. 

## Changelog
- Added API call for `delete`
- Modified `getToken()` to remove newline

## Dependencies 
As in DIG-793
You need to follow the [following document](https://candig.atlassian.net/wiki/spaces/CA/pages/623116353/Authorisation+-+Vault+helper+tool#Setup-Vault-for-the-task) to create a Keycloak and Vault instance. More instructions in the README.md.