### PR TITLE
DIG-663 - Add to Candigv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,46 +8,7 @@ In order to get started, follow the steps outlined in the [Deployment document](
 Then, run `go build` in the cli folder to build the CLI.
 
 ## How To Use the CLI
-
-Run the script `./cli` to set up a Vault dev server and run the code.
-
-Note, there are 3 commands implemented:
-
-- `write`: Can use this command as 
-```
-./cli write {json file}
-```
-or after running the cli as 
-```
-write {json file}
-```
-- `read`: Can use this command as 
-```
-./cli read {user's name}
-```
-or after running the cli as 
-```
-read {user's name}
-```
-- `list`: Can use this command as 
-```
-./cli list
-``` 
-or after running the cli as 
-```
-list 
-```
-- `help`: Can use this command as `./cli` or `./cli -h` or `./cli help`. This command will show information about the CLI.
-
-- `delete`: Can use the command as
-```
-./cli delete {user's name}
-```
-or after running the cli as
-```
-delete {user's name}
-```
-
+Navigate to the root of the Candigv2 Repository.
 There are two ways to access the CLI:
 - By running it in interactive mode (note the aliases can be used instead of the full command), for example: 
 ```
@@ -75,9 +36,10 @@ $ ./cli l
 $ ./cli d user
 $ ./cli help
 ```
+Further information can be found in [`Test-VHT.md`](/docs/Test-VHT.md)
 ## Verify that Data in Vault
 
-Use the following vault commmand to list out the users in vault:
+Use the following vault command to list out the users in vault:
 ```
 $ vault list identity/entity/name
 ```
@@ -123,3 +85,6 @@ curl -H "X-Vault-Token: "insert-client-token-here" http://docker.localhost:8200/
 ```
 This should generate the JWT, and go to [JWT.io](https://jwt.io/) to verify if it is correct.
 
+## Technical Debt
+
+Technical debt is documented in [`Further-Notes.md`](docs/Further-Notes.md)

--- a/cli/auth/readToken.go
+++ b/cli/auth/readToken.go
@@ -4,14 +4,13 @@ import (
 	"cli/cli/settings"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 )
 
 // returns obtained token
 func ReadToken() (string, error) {
-	absPath, _ := filepath.Abs(settings.TOKEN_PATH)
-	token, err := ioutil.ReadFile(absPath) // just pass the file name
+	fmt.Println(settings.TOKEN_PATH)
+	token, err := ioutil.ReadFile(settings.TOKEN_PATH) // just pass the file name
 	if err != nil {
 		return "", fmt.Errorf("reading token file errored. %w", err)
 	}

--- a/cli/auth/readToken.go
+++ b/cli/auth/readToken.go
@@ -9,7 +9,6 @@ import (
 
 // returns obtained token
 func ReadToken() (string, error) {
-	fmt.Println(settings.TOKEN_PATH)
 	token, err := ioutil.ReadFile(settings.TOKEN_PATH) // just pass the file name
 	if err != nil {
 		return "", fmt.Errorf("reading token file errored. %w", err)

--- a/cli/handlers/handlers.go
+++ b/cli/handlers/handlers.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
-// Used to write metadata to vault
 func HandleWrite(jsonName string, tx *api.Client) error {
 	jsonFile, err := os.Open(jsonName)
 	if err != nil {
@@ -71,6 +70,11 @@ func HandleList(tx *api.Client) (*api.Secret, error) {
 
 func HandleDelete(name string, tx *api.Client) error {
 	endpoint := "identity/entity/name/" + name
+	_, err := HandleRead(name, tx)
+	if err != nil {
+		err := name + " does not exist in Vault."
+		return fmt.Errorf(err)
+	}
 	secret, err := tx.Logical().Delete(endpoint)
 	if err != nil {
 		return fmt.Errorf("unable to delete secret: %v", err)

--- a/cli/handlers/handlers.go
+++ b/cli/handlers/handlers.go
@@ -87,43 +87,30 @@ func HandleDelete(name string, tx *api.Client) error {
 }
 
 func HandleUpdateRole(jsonName string, roleName string, tx *api.Client) error {
-
 	jsonFile, err := os.Open(jsonName)
-
 	if err != nil {
-
 		return fmt.Errorf("could not open file. %w", err)
-
 	}
-
 	byteValue, parseErr := ioutil.ReadAll(jsonFile)
-
 	if parseErr != nil {
 
 		return fmt.Errorf("error parsing data: %w", parseErr)
 
 	}
-
 	var value map[string]interface{}
-
 	marshErr := json.Unmarshal([]byte(byteValue), &value)
-
 	if marshErr != nil {
 
 		return fmt.Errorf("error using unmarshal: %w", marshErr)
 
 	}
-
 	_, err = tx.Logical().Write("auth/jwt/role/"+roleName, value)
-
 	if err != nil {
 
 		return fmt.Errorf("unable to write secret: %w", err)
 
 	}
-
 	jsonFile.Close()
-
 	return nil
 
 }

--- a/cli/handlers/handlers.go
+++ b/cli/handlers/handlers.go
@@ -85,3 +85,45 @@ func HandleDelete(name string, tx *api.Client) error {
 	}
 	return nil
 }
+
+func HandleUpdateRole(jsonName string, roleName string, tx *api.Client) error {
+
+	jsonFile, err := os.Open(jsonName)
+
+	if err != nil {
+
+		return fmt.Errorf("could not open file. %w", err)
+
+	}
+
+	byteValue, parseErr := ioutil.ReadAll(jsonFile)
+
+	if parseErr != nil {
+
+		return fmt.Errorf("error parsing data: %w", parseErr)
+
+	}
+
+	var value map[string]interface{}
+
+	marshErr := json.Unmarshal([]byte(byteValue), &value)
+
+	if marshErr != nil {
+
+		return fmt.Errorf("error using unmarshal: %w", marshErr)
+
+	}
+
+	_, err = tx.Logical().Write("auth/jwt/role/"+roleName, value)
+
+	if err != nil {
+
+		return fmt.Errorf("unable to write secret: %w", err)
+
+	}
+
+	jsonFile.Close()
+
+	return nil
+
+}

--- a/cli/interactiveApp.go
+++ b/cli/interactiveApp.go
@@ -39,6 +39,8 @@ func interactiveApp(tx *api.Client) {
 			response, err = middleware.List(tx)
 		} else if (command == "delete" || command == "d") && len(args) == 1 {
 			response, err = middleware.Delete(args[0], tx)
+		} else if (command == "updateRole" || command == "ur") && len(args) == 2 {
+			response, err = middleware.UpdateRole(args[0], args[1], tx)
 		} else if command == "exit" || command == "q" {
 			break
 		} else {

--- a/cli/interactiveApp.go
+++ b/cli/interactiveApp.go
@@ -49,6 +49,7 @@ func interactiveApp(tx *api.Client) {
 
 		// Respond to user
 		if err != nil {
+			printToLogFile(err)
 			fmt.Println(fmt.Errorf("middleware errored: %w", err))
 			continue
 		}
@@ -56,6 +57,7 @@ func interactiveApp(tx *api.Client) {
 		fmt.Print(inputPrompt)
 	}
 	if err := scanner.Err(); err != nil {
+		printToLogFile(err)
 		log.Println(err)
 	}
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -31,10 +31,28 @@ func connect() (*api.Client, error) {
 	return tx, nil
 }
 
+func printToLogFile(errorOutput error) {
+	file, err := os.OpenFile("commands.txt", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		fmt.Println("Could not open commands.txt")
+		return
+	}
+
+	defer file.Close()
+
+	_, err2 := file.WriteString(errorOutput.Error() + "\n")
+
+	if err2 != nil {
+		fmt.Println("Could not write text to commands.txt")
+
+	}
+}
+
 func main() {
 	fmt.Println("Connecting to Vault using token in token.txt")
 	tx, err := connect()
 	if err != nil {
+		printToLogFile(err)
 		log.Fatal(err)
 	}
 
@@ -125,6 +143,7 @@ func main() {
 
 	err = app.Run(os.Args)
 	if err != nil {
+		printToLogFile(err)
 		log.Fatal(err)
 	}
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -32,9 +32,9 @@ func connect() (*api.Client, error) {
 }
 
 func printToLogFile(errorOutput error) {
-	file, err := os.OpenFile("commands.txt", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	file, err := os.OpenFile("VHT-logs.txt", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
-		fmt.Println("Could not open commands.txt")
+		fmt.Println("Could not open VHT-logs.txt")
 		return
 	}
 
@@ -43,7 +43,7 @@ func printToLogFile(errorOutput error) {
 	_, err2 := file.WriteString(errorOutput.Error() + "\n")
 
 	if err2 != nil {
-		fmt.Println("Could not write text to commands.txt")
+		fmt.Println("Could not write text to VHT-logs.txt")
 
 	}
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -102,6 +102,22 @@ func main() {
 					return nil
 				},
 			},
+			{
+				Name:    "updateRole",
+				Aliases: []string{"ur"},
+				Usage:   "update role in vault (provide 2 argument - filename, name of role)",
+				Action: func(c *cli.Context) error {
+					jsonFile := c.Args().Get(0)
+					role := c.Args().Get(1)
+					response, err := middleware.UpdateRole(jsonFile, role, tx)
+					if err != nil {
+						return fmt.Errorf("middleware errored: %w", err)
+					}
+
+					fmt.Println(response)
+					return nil
+				},
+			},
 		},
 	}
 

--- a/cli/middleware/middleware.go
+++ b/cli/middleware/middleware.go
@@ -79,3 +79,22 @@ func Delete(user string, tx *api.Client) (string, error) {
 
 	return response, nil
 }
+
+func UpdateRole(jsonFilename string, roleName string, tx *api.Client) (string, error) {
+	err := v.ValidateUpdateRole(jsonFilename, roleName)
+	if err != nil {
+		return "", fmt.Errorf("validation failed: %w", err)
+	}
+
+	err = h.HandleUpdateRole(jsonFilename, roleName, tx)
+	if err != nil {
+		return "", fmt.Errorf("handling failed: %w", err)
+	}
+
+	response, err := r.RespondToUpdateRole()
+	if err != nil {
+		return "", fmt.Errorf("response-generation failed: %w", err)
+	}
+
+	return response, nil
+}

--- a/cli/responders/responders.go
+++ b/cli/responders/responders.go
@@ -42,3 +42,7 @@ func RespondToList(listSecret *api.Secret, tx *api.Client) (string, error) {
 func RespondToDelete() (string, error) {
 	return ("User deleted successfully."), nil
 }
+
+func RespondToUpdateRole() (string, error) {
+	return "Role updated successfully.", nil
+}

--- a/cli/settings/getEnvironemntVariables.go
+++ b/cli/settings/getEnvironemntVariables.go
@@ -1,0 +1,19 @@
+package settings
+
+import (
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+func GetEnvironmentVariable(variableName string, defaultName string) string {
+	envVar, ok := os.LookupEnv(variableName)
+	if !ok {
+		err := godotenv.Load(path + "/.env")
+		if err != nil {
+			return defaultName
+		}
+		return os.Getenv(variableName)
+	}
+	return envVar
+}

--- a/cli/settings/settings.go
+++ b/cli/settings/settings.go
@@ -2,28 +2,16 @@ package settings
 
 import (
 	"os"
-
-	"github.com/joho/godotenv"
 )
 
-func GetEnvironmentVariable(variableName string, defaultName string) string {
-	envVar, ok := os.LookupEnv(variableName)
-	if !ok {
-		err := godotenv.Load(path + "/.env")
-		if err != nil {
-			return defaultName
-		}
-		return os.Getenv(variableName)
-	}
-	return envVar
-}
-
 var path, _ = os.Getwd()
+
+// Hardcoded variables
 var DEFAULT_VAULT_ADDRESS = "http://127.0.0.1:8200"
 var DEFAULT_TOKEN_PATH = "/Vault-Helper-Tool/token.txt"
 
+// Environment variables
 var VAULT_ADDRESS = GetEnvironmentVariable("VAULT_SERVICE_PUBLIC_URL", DEFAULT_VAULT_ADDRESS)
-
 var TOKEN_PATH = path + GetEnvironmentVariable("TOKEN_PATH", DEFAULT_TOKEN_PATH)
 
 //var PROGRESS_FILE = goDotEnvVariable("PROGRESS_FILE")

--- a/cli/settings/settings.go
+++ b/cli/settings/settings.go
@@ -1,7 +1,6 @@
 package settings
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -10,22 +9,21 @@ import (
 func GetEnvironmentVariable(variableName string, defaultName string) string {
 	envVar, ok := os.LookupEnv(variableName)
 	if !ok {
-		err := godotenv.Load(path + ".env")
+		err := godotenv.Load(path + "/.env")
 		if err != nil {
 			return defaultName
 		}
-		fmt.Println(os.Getenv(envVar))
-		return os.Getenv(envVar)
+		return os.Getenv(variableName)
 	}
 	return envVar
 }
 
 var path, _ = os.Getwd()
 var DEFAULT_VAULT_ADDRESS = "http://127.0.0.1:8200"
-var DEFAULT_TOKEN_PATH = path + "/Vault-Helper-Tool/token.txt"
+var DEFAULT_TOKEN_PATH = "/Vault-Helper-Tool/token.txt"
 
 var VAULT_ADDRESS = GetEnvironmentVariable("VAULT_SERVICE_PUBLIC_URL", DEFAULT_VAULT_ADDRESS)
 
-var TOKEN_PATH = GetEnvironmentVariable("TOKEN_PATH", DEFAULT_TOKEN_PATH)
+var TOKEN_PATH = path + GetEnvironmentVariable("TOKEN_PATH", DEFAULT_TOKEN_PATH)
 
 //var PROGRESS_FILE = goDotEnvVariable("PROGRESS_FILE")

--- a/cli/settings/settings.go
+++ b/cli/settings/settings.go
@@ -1,4 +1,31 @@
 package settings
 
-var VAULT_ADDRESS = "http://127.0.0.1:8200"
-var TOKEN_PATH = "../token.txt"
+import (
+	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+func GetEnvironmentVariable(variableName string, defaultName string) string {
+	envVar, ok := os.LookupEnv(variableName)
+	if !ok {
+		err := godotenv.Load(path + ".env")
+		if err != nil {
+			return defaultName
+		}
+		fmt.Println(os.Getenv(envVar))
+		return os.Getenv(envVar)
+	}
+	return envVar
+}
+
+var path, _ = os.Getwd()
+var DEFAULT_VAULT_ADDRESS = "http://127.0.0.1:8200"
+var DEFAULT_TOKEN_PATH = path + "/Vault-Helper-Tool/token.txt"
+
+var VAULT_ADDRESS = GetEnvironmentVariable("VAULT_SERVICE_PUBLIC_URL", DEFAULT_VAULT_ADDRESS)
+
+var TOKEN_PATH = GetEnvironmentVariable("TOKEN_PATH", DEFAULT_TOKEN_PATH)
+
+//var PROGRESS_FILE = goDotEnvVariable("PROGRESS_FILE")

--- a/cli/validators/validators.go
+++ b/cli/validators/validators.go
@@ -40,3 +40,13 @@ func ValidateDelete(arg1 string) error {
 	}
 	return nil
 }
+
+func ValidateUpdateRole(arg1 string, arg2 string) error {
+	if arg1 == "" {
+		return errors.New("no arguments provided, missing filename")
+	}
+	if arg2 == "" {
+		return errors.New("no arguments provided, missing role's name")
+	}
+	return nil
+}

--- a/docs/Further-Notes.md
+++ b/docs/Further-Notes.md
@@ -4,10 +4,10 @@
 - Need root token to use for now (should theoretically be able to use other tokens as well)
 - Cannot add q as command due to how urfave cli is structure, so added with input prompt
 - `POST` overwrites metadata, since Vault's API command overwrites metadata
-- Whenever adding new datasets, update the template in the [Setup Instructions](https://candig.atlassian.net/wiki/spaces/CA/pages/623116353/Authorisation+-+Vault+helper+tool) accordingly for generating the JWTJWT.
+- Whenever adding new datasets, update the template in the [Setup Instructions](https://candig.atlassian.net/wiki/spaces/CA/pages/623116353/Authorisation+-+Vault+helper+tool) accordingly for generating the JWT.
 
 ### Avenues for Improvement
-- Some code reused between interactive mode and cli. Explore if ur fave cli has a similar interface that can be easily integrated
-- Try this tool with non-root token (and correct permissions)
-- Fix the docker compose file so both Vault and Keycloak are generated automatically
+- Some code reused between interactive mode and cli. Explore if ur fave cli has a similar interface that can be easily integrated.
 - number-of-arguments validator should be shared between interactiveApp (interactive mode) and main (single-command mode) and refactor should modify the len(args)==n conditions below.
+- Use the [Add-bearer-token](https://github.com/CanDIG/Vault-Helper-Tool/tree/Add-bearer-token) branch to authenticate with bearer token instead of access token.
+- Add the vault helper tool as a docker container since not everyone has golang installed,

--- a/docs/Test-VHT.md
+++ b/docs/Test-VHT.md
@@ -1,0 +1,129 @@
+# User Guide on How to Smoke-Test the Vault Helper Tool
+
+## How to run
+From the root of the `Candigv2` repository, run 
+```
+./Vault-Helper-Tool/cli/cli {command} {optional-arguments}
+```
+## How to use Tool
+
+- To call `write`, use:
+```
+./Vault-Helper-Tool/cli/cli write {json file}
+```
+or after running the cli as 
+```
+write {json file}
+```
+
+- To call `read`, use:
+
+```
+./Vault-Helper-Tool/cli/cli read {user's name}
+```
+or after running the cli as 
+```
+read {user's name}
+```
+
+- To call `delete`, use:
+```
+./Vault-Helper-Tool/cli/cli delete {user's name}
+```
+or after running the cli as
+```
+delete {user's name}
+```
+
+- To call `list`, use:
+
+```
+./Vault-Helper-Tool/cli/cli list
+``` 
+or after running the cli as 
+```
+list 
+```
+
+- To call `help`, use:
+
+```
+./Vault-Helper-Tool/cli/cli -h
+``` 
+or after running the cli as 
+```
+./Vault-Helper-Tool/cli/cli 
+```
+
+## Examples for Proper usage
+- Write:
+```
+$ ./Vault-Helper-Tool/cli/cli write ../example.json
+Secret written successfully.
+```
+- Read:
+```
+$ ./Vault-Helper-Tool/cli/cli read entity_1cd0efa6
+Connecting to Vault using token in token.txt
+{"dataset123":"4","dataset321":"4"}
+```
+- Delete:
+```
+$ ./Vault-Helper-Tool/cli/cli delete entity_1cd0efa6
+User deleted successfully.
+```
+- List: 
+```
+$ ./Vault-Helper-Tool/cli/cli list
+Connecting to Vault using token in token.txt
+entity_1cd0efa6
+{"dataset123":"4","dataset321":"4"}
+-------------------------
+entity_c65b1f1a
+{"dataset123":"1","dataset321":"1"}
+-------------------------
+```
+## How to Trigger Errors
+
+### Incorrect number of arguments
+```
+$ ./Vault-Helper-Tool/cli/cli write
+Connecting to Vault using token in token.txt
+2022/04/12 05:49:59 middleware errored: validation failed: file name not provided
+```
+
+```
+$ ./Vault-Helper-Tool/cli/cli read
+Connecting to Vault using token in token.txt
+2022/04/12 05:49:32 middleware errored: validation failed: no arguments provided, missing user's name
+```
+
+```
+./Vault-Helper-Tool/cli/cli delete
+Connecting to Vault using token in token.txt
+2022/04/12 05:50:35 middleware errored: validation failed: no arguments provided, missing user's name
+```
+
+### Wrong file name
+```
+$ ./Vault-Helper-Tool/cli/cli write non-file.json
+Connecting to Vault using token in token.txt
+2022/04/12 05:53:07 middleware errored: handling failed: could not open file. open non-file.json: no such file or directory
+
+```
+
+### User does not exist in vault
+
+```
+$ ./Vault-Helper-Tool/cli/cli read non-user
+Connecting to Vault using token in token.txt
+2022/04/12 05:52:36 middleware errored: handling failed: non-user does not exist in Vault.
+```
+
+```
+$ ./Vault-Helper-Tool/cli/cli delete non-user
+Connecting to Vault using token in token.txt
+2022/04/14 10:43:15 middleware errored: handling failed: non-user does not exist in Vault.
+
+```
+

--- a/docs/Test-VHT.md
+++ b/docs/Test-VHT.md
@@ -1,15 +1,21 @@
-# User Guide on How to Smoke-Test the Vault Helper Tool
+# User Guide on How to Test the Vault Helper Tool
 
 ## How to run
+Ensure that you have followed the commands in `install-docker.md` to initialize Candigv2 with docker, then run 
+```
+make compose
+make init-authx
+```
+After this, look at the `keys.txt` file in the vault folder to find the root access token. This token will need to be updated in the `token.txt` file in the root directory. 
 From the root of the `Candigv2` repository, run 
 ```
-./Vault-Helper-Tool/cli/cli {command} {optional-arguments}
+./path-to-cli {command} {optional-arguments}
 ```
 ## How to use Tool
 
 - To call `write`, use:
 ```
-./Vault-Helper-Tool/cli/cli write {json file}
+./path-to-cli write {json file}
 ```
 or after running the cli as 
 ```
@@ -19,7 +25,7 @@ write {json file}
 - To call `read`, use:
 
 ```
-./Vault-Helper-Tool/cli/cli read {user's name}
+./path-to-cli read {user's name}
 ```
 or after running the cli as 
 ```
@@ -28,7 +34,7 @@ read {user's name}
 
 - To call `delete`, use:
 ```
-./Vault-Helper-Tool/cli/cli delete {user's name}
+./path-to-cli delete {user's name}
 ```
 or after running the cli as
 ```
@@ -38,43 +44,52 @@ delete {user's name}
 - To call `list`, use:
 
 ```
-./Vault-Helper-Tool/cli/cli list
+./path-to-cli list
 ``` 
 or after running the cli as 
 ```
 list 
 ```
 
+- To call `updateRole`, use:
+```
+$ ./path-to-cli updateRole {path-to-json-for-role} {role}
+```
+or after running the cli as 
+```
+updateRole {path-to-json-for-role} {role}
+```
+
 - To call `help`, use:
 
 ```
-./Vault-Helper-Tool/cli/cli -h
+./path-to-cli -h
 ``` 
 or after running the cli as 
 ```
-./Vault-Helper-Tool/cli/cli 
+./path-to-cli 
 ```
 
 ## Examples for Proper usage
 - Write:
 ```
-$ ./Vault-Helper-Tool/cli/cli write ../example.json
+$ ./path-to-cli write Vault-Helper-Tool/example.json
 Secret written successfully.
 ```
 - Read:
 ```
-$ ./Vault-Helper-Tool/cli/cli read entity_1cd0efa6
+$ ./path-to-cli read entity_1cd0efa6
 Connecting to Vault using token in token.txt
 {"dataset123":"4","dataset321":"4"}
 ```
 - Delete:
 ```
-$ ./Vault-Helper-Tool/cli/cli delete entity_1cd0efa6
+$ ./path-to-cli delete entity_1cd0efa6
 User deleted successfully.
 ```
 - List: 
 ```
-$ ./Vault-Helper-Tool/cli/cli list
+$ ./path-to-cli list
 Connecting to Vault using token in token.txt
 entity_1cd0efa6
 {"dataset123":"4","dataset321":"4"}
@@ -83,47 +98,64 @@ entity_c65b1f1a
 {"dataset123":"1","dataset321":"1"}
 -------------------------
 ```
+- updateRole
+```
+$ ./path-to-cli updateRole researcher Vault-Helper-Tool/role.json
+Connecting to Vault using token in token.txt
+Role updated successfully.
+```
 ## How to Trigger Errors
 
 ### Incorrect number of arguments
 ```
-$ ./Vault-Helper-Tool/cli/cli write
+$ ./path-to-cli write
 Connecting to Vault using token in token.txt
 2022/04/12 05:49:59 middleware errored: validation failed: file name not provided
 ```
 
 ```
-$ ./Vault-Helper-Tool/cli/cli read
+$ ./path-to-cli read
 Connecting to Vault using token in token.txt
 2022/04/12 05:49:32 middleware errored: validation failed: no arguments provided, missing user's name
 ```
 
 ```
-./Vault-Helper-Tool/cli/cli delete
+./path-to-cli delete
 Connecting to Vault using token in token.txt
 2022/04/12 05:50:35 middleware errored: validation failed: no arguments provided, missing user's name
+```
+```
+./path-to-cli updateRole
+Connecting to Vault using token in token.txt
+2022/04/12 05:50:35 middleware errored: validation failed: no arguments provided, missing filename
 ```
 
 ### Wrong file name
 ```
-$ ./Vault-Helper-Tool/cli/cli write non-file.json
+$ ./path-to-cli write non-file.json
 Connecting to Vault using token in token.txt
 2022/04/12 05:53:07 middleware errored: handling failed: could not open file. open non-file.json: no such file or directory
 
 ```
 
-### User does not exist in vault
+### User/Role does not exist in vault
 
 ```
-$ ./Vault-Helper-Tool/cli/cli read non-user
+$ ./path-to-cli read non-user
 Connecting to Vault using token in token.txt
 2022/04/12 05:52:36 middleware errored: handling failed: non-user does not exist in Vault.
 ```
 
 ```
-$ ./Vault-Helper-Tool/cli/cli delete non-user
+$ ./path-to-cli delete non-user
 Connecting to Vault using token in token.txt
 2022/04/14 10:43:15 middleware errored: handling failed: non-user does not exist in Vault.
 
 ```
 
+```
+$ ./path-to-cli ur Vault-Helper-Tool/non-role.json researcher
+Connecting to Vault using token in token.txt
+2022/04/19 08:20:39 middleware errored: handling failed: could not open file. open Vault-Helper-Tool/non-role.json: no such file or directory
+
+```

--- a/docs/Test-VHT.md
+++ b/docs/Test-VHT.md
@@ -6,16 +6,27 @@ Ensure that you have followed the commands in `install-docker.md` to initialize 
 make compose
 make init-authx
 ```
-After this, look at the `keys.txt` file in the vault folder to find the root access token. This token will need to be updated in the `token.txt` file in the root directory. 
+After this, look at the `keys.txt` file in the vault folder to find the root access token. This token will need to be updated in the `token.txt` file in the root directory.
+Then either run
+```
+go install -v https://github.com/CanDIG/Vault-Helper-Tool
+```
+or run the following commands from the root of the Candigv2 repo to copy over the binary file. (This is necessary since the paths in the settings are configured to work for Candigv2).
+```
+cd lib/vault/Vault-Helper-Tool/cli \
+go build \
+cd - \
+cp lib/vault/Vault-Helper-Tool/cli/cli .
+```
 From the root of the `Candigv2` repository, run 
 ```
-./path-to-cli {command} {optional-arguments}
+./cli {command} {optional-arguments}
 ```
 ## How to use Tool
 
 - To call `write`, use:
 ```
-./path-to-cli write {json file}
+./cli write {json file}
 ```
 or after running the cli as 
 ```
@@ -25,7 +36,7 @@ write {json file}
 - To call `read`, use:
 
 ```
-./path-to-cli read {user's name}
+./cli read {user's name}
 ```
 or after running the cli as 
 ```
@@ -34,7 +45,7 @@ read {user's name}
 
 - To call `delete`, use:
 ```
-./path-to-cli delete {user's name}
+./cli delete {user's name}
 ```
 or after running the cli as
 ```
@@ -44,7 +55,7 @@ delete {user's name}
 - To call `list`, use:
 
 ```
-./path-to-cli list
+./cli list
 ``` 
 or after running the cli as 
 ```
@@ -53,7 +64,7 @@ list
 
 - To call `updateRole`, use:
 ```
-$ ./path-to-cli updateRole {path-to-json-for-role} {role}
+$ ./cli updateRole {path-to-json-for-role} {role}
 ```
 or after running the cli as 
 ```
@@ -63,33 +74,33 @@ updateRole {path-to-json-for-role} {role}
 - To call `help`, use:
 
 ```
-./path-to-cli -h
+./cli -h
 ``` 
 or after running the cli as 
 ```
-./path-to-cli 
+./cli 
 ```
 
 ## Examples for Proper usage
 - Write:
 ```
-$ ./path-to-cli write Vault-Helper-Tool/example.json
+$ ./cli write Vault-Helper-Tool/example.json
 Secret written successfully.
 ```
 - Read:
 ```
-$ ./path-to-cli read entity_1cd0efa6
+$ ./cli read entity_1cd0efa6
 Connecting to Vault using token in token.txt
 {"dataset123":"4","dataset321":"4"}
 ```
 - Delete:
 ```
-$ ./path-to-cli delete entity_1cd0efa6
+$ ./cli delete entity_1cd0efa6
 User deleted successfully.
 ```
 - List: 
 ```
-$ ./path-to-cli list
+$ ./cli list
 Connecting to Vault using token in token.txt
 entity_1cd0efa6
 {"dataset123":"4","dataset321":"4"}
@@ -100,7 +111,7 @@ entity_c65b1f1a
 ```
 - updateRole
 ```
-$ ./path-to-cli updateRole researcher Vault-Helper-Tool/role.json
+$ ./cli updateRole researcher Vault-Helper-Tool/role.json
 Connecting to Vault using token in token.txt
 Role updated successfully.
 ```
@@ -108,31 +119,31 @@ Role updated successfully.
 
 ### Incorrect number of arguments
 ```
-$ ./path-to-cli write
+$ ./cli write
 Connecting to Vault using token in token.txt
 2022/04/12 05:49:59 middleware errored: validation failed: file name not provided
 ```
 
 ```
-$ ./path-to-cli read
+$ ./cli read
 Connecting to Vault using token in token.txt
 2022/04/12 05:49:32 middleware errored: validation failed: no arguments provided, missing user's name
 ```
 
 ```
-./path-to-cli delete
+./cli delete
 Connecting to Vault using token in token.txt
 2022/04/12 05:50:35 middleware errored: validation failed: no arguments provided, missing user's name
 ```
 ```
-./path-to-cli updateRole
+./cli updateRole
 Connecting to Vault using token in token.txt
 2022/04/12 05:50:35 middleware errored: validation failed: no arguments provided, missing filename
 ```
 
 ### Wrong file name
 ```
-$ ./path-to-cli write non-file.json
+$ ./cli write non-file.json
 Connecting to Vault using token in token.txt
 2022/04/12 05:53:07 middleware errored: handling failed: could not open file. open non-file.json: no such file or directory
 
@@ -141,20 +152,20 @@ Connecting to Vault using token in token.txt
 ### User/Role does not exist in vault
 
 ```
-$ ./path-to-cli read non-user
+$ ./cli read non-user
 Connecting to Vault using token in token.txt
 2022/04/12 05:52:36 middleware errored: handling failed: non-user does not exist in Vault.
 ```
 
 ```
-$ ./path-to-cli delete non-user
+$ ./cli delete non-user
 Connecting to Vault using token in token.txt
 2022/04/14 10:43:15 middleware errored: handling failed: non-user does not exist in Vault.
 
 ```
 
 ```
-$ ./path-to-cli ur Vault-Helper-Tool/non-role.json researcher
+$ ./cli ur Vault-Helper-Tool/non-role.json researcher
 Connecting to Vault using token in token.txt
 2022/04/19 08:20:39 middleware errored: handling failed: could not open file. open Vault-Helper-Tool/non-role.json: no such file or directory
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/vault/sdk v0.4.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
+	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/role.json
+++ b/role.json
@@ -1,0 +1,7 @@
+{
+    "user_claim": "preferred_username",
+    "role_type": "jwt",
+    "policies": "tyk",
+    "ttl": "1h",
+    "bound_audiences": "candig"
+}


### PR DESCRIPTION
## Description
This PR deals with the ticket [DIG-663](candig.atlassian.net/browse/DIG-663). The configuration options are now set to read from:
1. Environment variables from the shell
2. Reading the `.env` folder from the root of the `Candigv2` repo
3. Hardcoded addresses

Logging was also added and can be seen in the root of the candigv2 repo in the `VHT-logs.txt` file (Daisie mentioned that it did not have to write to the `progress.txt` file and could instead use another file).
I attempted to use a bearer token for authorisation, and have added my attempts in the [Add-bearer-token](https://github.com/CanDIG/Vault-Helper-Tool/tree/Add-bearer-token) branch, but the vault api package used here does not allow for authorization with a bearer token so that is left out in this PR.
I also attempted to add the vault helper tool as a docker container since not everyone has golang installed, but this was left out for timing purposes
## Changelog
- changed configuration options in `settings.go`
- added command for updating the role of a researcher
- added logging for VHT 
- added smoke testing guide to repo in `docs/Test-VHT.md`
- updated technical debt for VHT
## Dependencies
Needs to be run from the root of the `Candigv2` repo.
## Testing
First add the token to the token.txt file.
Then either run 
```
go install -v https://github.com/CanDIG/Vault-Helper-Tool
```
or run the following commands from the root of the Candigv2 repo to copy over the binary file. (This is necessary since the paths in the settings are configured to work for Candigv2). 
```
cd lib/vault/Vault-Helper-Tool/cli \
go build \
cd - \
cp lib/vault/Vault-Helper-Tool/cli/cli .
```
Then, from the root of the `Candigv2` repo, run 
```
./cli <command> <optional-args>
```